### PR TITLE
No mono runtime

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -71,7 +71,6 @@ ram.runtime = "50M"
 
     [resources.apt]
     packages = [
-        "mono-runtime",
         "sqlite3",
         "dirmngr",
         "mediainfo",


### PR DESCRIPTION
## Problem

- `mono-runtime` is unnecessary as `linux` builds are proper `ELF` files

## Solution

- Remove extra dep

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
