### PR TITLE
Fix packaging v2 migration

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -10,7 +10,7 @@ location __PATH__ {
   proxy_set_header Upgrade $http_upgrade;
   proxy_set_header Connection $http_connection;
   
-  # Allow the Radarr API
+  # Allow the Sonarr API
   location __PATH__/api {
     auth_request off;
     proxy_pass http://127.0.0.1:__PORT____PATH__/api;

--- a/manifest.toml
+++ b/manifest.toml
@@ -57,7 +57,6 @@ ram.runtime = "50M"
     [resources.install_dir]
 
     [resources.data_dir]
-    dir = "/var/lib/__APP__"
 
     [resources.ports]
 

--- a/scripts/install
+++ b/scripts/install
@@ -32,7 +32,7 @@ chown -R "$app:$app" "$install_dir"
 #=================================================
 # ADD A CONFIGURATION
 #=================================================
-ynh_script_progression --message="Configuring Radarr..." --weight=2
+ynh_script_progression --message="Configuring Sonarr..." --weight=2
 
 mkdir -p "/var/log/$app"
 ln -s "/var/log/$app" "$data_dir/logs"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -23,6 +23,15 @@ ynh_systemd_action --service_name="$app" --action="stop" --log_path="systemd"
 #=================================================
 ynh_script_progression --message="Ensuring downward compatibility..." --weight=1
 
+# Fixes specific to packaging v2 migration
+if ynh_compare_current_package_version --comparison le --version 3.0.6.1196~ynh3
+then
+    # In packaging v1, final_path=/var/lib/$app but actually held the data. No data_dir was defined
+    # Upon migration, the core moves /var/lib/$app to /var/www/$app, so let's move it to the data_dir
+    ynh_print_warn --message="Fix manivest v2 migration: moving contents of $install_dir to $data_dir... (this may take a while)"
+    mv $install_dir/* $data_dir
+fi
+
 if [ ! -L "$data_dir/logs" ]; then
     ynh_secure_remove --file="$data_dir/logs"
     ln -s "/var/log/$app" "$data_dir/logs"

--- a/tests.toml
+++ b/tests.toml
@@ -8,8 +8,9 @@ test_format = 1.0
     # Default args to use for install
     # -------------------------------
 
-    args.admin="john"
-
     # ------------
     # Tests to run
     # ------------
+
+    test_upgrade_from.768c1ce.name = "Upgrade from 3.0.6.1196~ynh3 (packaging v1)"
+    test_upgrade_from.768c1ce.args.admin = "package_checker"

--- a/tests.toml
+++ b/tests.toml
@@ -13,4 +13,6 @@ test_format = 1.0
     # ------------
 
     test_upgrade_from.768c1ce.name = "Upgrade from 3.0.6.1196~ynh3 (packaging v1)"
+    test_upgrade_from.768c1ce.args.domain = "domain.tld"
+    test_upgrade_from.768c1ce.args.path = "/sonarr"
     test_upgrade_from.768c1ce.args.admin = "package_checker"


### PR DESCRIPTION
In packaging v1, final_path=/var/lib/$app but actually held the data. No data_dir was defined
Upon migration, the core moves /var/lib/$app to /var/www/$app, so let's move it to the data_dir

Issues were reported on Matrix and the [forum](https://forum.yunohost.org/t/sonarr-a-series-collection-manager-for-usenet-and-bittorrent-users/16113/6).

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
